### PR TITLE
Added missing includes using element directives

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ module.exports = function(options) {
 
     // Use while to make the task recursive
     while (true) {
-      var tags = $('ng-include, [ng-include]');
+      var tags = $('ng-include[src], [ng-include]');
 
       // If we don't find any more ng-include tags, we're done
       if(tags.length === 0) {

--- a/test/expected/test-element.html
+++ b/test/expected/test-element.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Title</title>
+</head>
+<body ontouchstart="" ng-controller="MainCtrl">
+  <ng-include src="foo" class="mydiv"></ng-include>
+  <ng-include class="mydiv">
+<!-- ngInclude: 'partial-1.html' -->
+<p>foo</p>
+<!--/ngInclude: 'partial-1.html' -->
+</ng-include>
+  <ng-include class="mydiv">
+<!-- ngInclude: 'partial-2.html' -->
+<p>bar</p>
+<!--/ngInclude: 'partial-2.html' -->
+</ng-include>
+</body>
+</html>

--- a/test/fixtures/test-element.html
+++ b/test/fixtures/test-element.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Title</title>
+</head>
+<body ontouchstart ng-controller="MainCtrl">
+  <ng-include src="foo" class="mydiv"></ng-include>
+  <ng-include src="'partial-1.html'" class="mydiv"></ng-include>
+  <ng-include src="'partial-2.html'" class="mydiv"></ng-include>
+</body>
+</html>

--- a/test/main.js
+++ b/test/main.js
@@ -85,6 +85,26 @@ describe('gulp-nginclude', function() {
 
     });
 
+    it('should properly include templates utilizing the element directive', function(done) {
+      var fixture = new File(extend({contents: fs.readFileSync(__dirname + '/fixtures/test-element.html')}, defaults));
+      var expected = fs.readFileSync(__dirname + '/expected/test-element.html');
+
+      var stream = nginclude();
+      stream.on('data', function(newFile) {
+        should.exist(newFile);
+        should.exist(newFile.path);
+        should.exist(newFile.relative);
+        should.exist(newFile.contents);
+        should.equal(newFile.contents.toString(), expected.toString());
+        newFile.path.should.equal(path.join(__dirname, 'fixtures/file.html'));
+        newFile.relative.should.equal('file.html');
+      });
+      stream.once('end', done);
+      stream.write(fixture);
+      stream.end();
+
+    });
+
     // it('should properly handle dynamic ngIncludes', function(done) {
 
     //   var fixture = new File(extend({contents: new Buffer('<div ng-include="foo"></div>\n<div ng-include="\'bar.html\'"></div>\n<div>baz</div>')}, defaults));


### PR DESCRIPTION
Added missing the option to include a template as an element . i.e.: <ng-include src="'views/header/header.html'"></ng-include>
